### PR TITLE
Various changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,4 @@ https://ministryofjustice.github.io/technical-guidance/standards/documenting-inf
 | access_key_id | Access key id for s3 account |
 | bucket_arn | Arn for s3 bucket created |
 | bucket_name | bucket name |
-| iam_user_name | user name for s3 service account |
 | secret_access_key | Secret key for s3 account |
-| user_arn | Arn for iam user |

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Terraform module that will create an S3 bucket in AWS with relevant user account
 The bucket created will prefix the business unit tag and your team name to the bucket identifier to create the bucket name. This ensures that the bucket created is globally unique and avoids name clashes.
 
 ```bash
-bucket name = ${business-unit}-${team_name}-${bucket_identifier} 
+bucket name = ${business-unit}-${team_name}-${bucket_identifier}
 ```
 
 ## Usage
@@ -30,7 +30,7 @@ module "example_team_s3" {
 | team_name |  | string | - | yes |
 | versioning | version objects stored within your bucket. | boolean | false | no |
 
-### Tags 
+### Tags
 
 Some of the inputs are tags. All infrastructure resources need to be tagged according to MOJ techincal guidence. The tags are stored as variables that you will need to fill out as part of your module.
 
@@ -53,13 +53,5 @@ https://ministryofjustice.github.io/technical-guidance/standards/documenting-inf
 | bucket_arn | Arn for s3 bucket created |
 | bucket_name | bucket name |
 | iam_user_name | user name for s3 service account |
-| policy_arn | ARN for the new policy |
 | secret_access_key | Secret key for s3 account |
 | user_arn | Arn for iam user |
-
-
-
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -2,11 +2,7 @@
 
 Terraform module that will create an S3 bucket in AWS with relevant user account that will have access to bucket.
 
-The bucket created will prefix the business unit tag and your team name to the bucket identifier to create the bucket name. This ensures that the bucket created is globally unique and avoids name clashes.
-
-```bash
-bucket name = ${business-unit}-${team_name}-${bucket_identifier}
-```
+The bucket created will have a randomised name of the format `cloud-platform-7a5c4a2a7e2134a`. This ensures that the bucket created is globally unique.
 
 ## Usage
 
@@ -15,7 +11,6 @@ module "example_team_s3" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=master"
 
   team_name         = "example-repo"
-  bucket_identifier = "example-bucket"
   acl               = "public-read"
   versioning        =  true
 }
@@ -26,8 +21,6 @@ module "example_team_s3" {
 | Name | Description | Type | Default | Required |
 |------|-------------|:----:|:-----:|:-----:|
 | acl | acl manages access to your bucket | string | `private` | no |
-| bucket_identifier | This is the bucket identifier, the bucket name will be this prefixed with your team name | string | - | yes |
-| team_name |  | string | - | yes |
 | versioning | version objects stored within your bucket. | boolean | false | no |
 
 ### Tags
@@ -43,6 +36,7 @@ https://ministryofjustice.github.io/technical-guidance/standards/documenting-inf
 | environment-name |  | string | - | yes |
 | infrastructure-support | The team responsible for managing the infrastructure. Should be of the form team-email | string | - | yes |
 | is-production |  | string | `false` | yes |
+| team_name |  | string | - | yes |
 
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -10,9 +10,14 @@ The bucket created will have a randomised name of the format `cloud-platform-7a5
 module "example_team_s3" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=master"
 
-  team_name         = "example-repo"
-  acl               = "public-read"
-  versioning        =  true
+  team_name              = "example-repo"
+  acl                    = "public-read"
+  versioning             =  true
+  business-unit          = "example-bu"
+  application            = "example-app"
+  is-production          = "false"
+  environment-name       = "development"
+  infrastructure-support = "example-team@digtal.justice.gov.uk"
 }
 ```
 

--- a/example/main.tf
+++ b/example/main.tf
@@ -6,7 +6,6 @@ module "example_team_s3" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=master"
 
   team_name              = "cloudplatform"
-  bucket_identifier      = "example-bucket"
   acl                    = "public-read"
   versioning             = true
   business-unit          = "mojdigital"

--- a/example/output.tf
+++ b/example/output.tf
@@ -1,8 +1,3 @@
-output "iam_user_name" {
-  description = "User name for s3 service account"
-  value       = "${module.example_team_s3.iam_user_name}"
-}
-
 output "access_key_id" {
   description = "Access key id for s3 account"
   value       = "${module.example_team_s3.access_key_id}"
@@ -21,9 +16,4 @@ output "bucket_arn" {
 output "bucket_name" {
   description = "bucket name"
   value       = "${module.example_team_s3.bucket_name}"
-}
-
-output "user_arn" {
-  description = "ARN for iam user"
-  value       = "${module.example_team_s3.user_arn}"
 }

--- a/example/output.tf
+++ b/example/output.tf
@@ -1,8 +1,3 @@
-output "policy_arn" {
-  description = "ARN for the new policy"
-  value       = "${module.example_team_s3.policy_arn}"
-}
-
 output "iam_user_name" {
   description = "User name for s3 service account"
   value       = "${module.example_team_s3.iam_user_name}"

--- a/main.tf
+++ b/main.tf
@@ -1,8 +1,12 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
+resource "random_id" "bucket" {
+  byte_length = 16
+}
+
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "${var.business-unit}-${var.team_name}-${var.bucket_identifier}"
+  bucket        = "cloud-platform-${random_id.bucket.hex}"
   acl           = "${var.acl}"
   force_destroy = "true"
   region        = "${data.aws_region.current.name}"

--- a/main.tf
+++ b/main.tf
@@ -1,12 +1,12 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-resource "random_id" "bucket" {
+resource "random_id" "id" {
   byte_length = 16
 }
 
 resource "aws_s3_bucket" "bucket" {
-  bucket        = "cloud-platform-${random_id.bucket.hex}"
+  bucket        = "cloud-platform-${random_id.id.hex}"
   acl           = "${var.acl}"
   force_destroy = "true"
   region        = "${data.aws_region.current.name}"
@@ -33,12 +33,8 @@ resource "aws_s3_bucket" "bucket" {
   }
 }
 
-resource "random_id" "user" {
-  byte_length = 8
-}
-
 resource "aws_iam_user" "user" {
-  name = "s3-bucket-user-${random_id.user.hex}"
+  name = "s3-bucket-user-${random_id.id.hex}"
   path = "/system/s3-bucket-user/${var.team_name}/"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -29,9 +29,13 @@ resource "aws_s3_bucket" "s3bucket" {
   }
 }
 
+resource "random_id" "user" {
+  byte_length = 8
+}
+
 resource "aws_iam_user" "s3-account" {
-  name = "${aws_s3_bucket.s3bucket.bucket}-s3-system-account"
-  path = "/teams/${var.team_name}/"
+  name = "s3-bucket-user-${random_id.user.hex}"
+  path = "/system/s3-bucket-user/${var.team_name}/"
 }
 
 resource "aws_iam_access_key" "s3-account-access-key" {

--- a/main.tf
+++ b/main.tf
@@ -81,8 +81,8 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.bucket.bucket}",
-      "arn:aws:s3:::${aws_s3_bucket.bucket.bucket}/*",
+      "arn:aws:s3:::${aws_s3_bucket.bucket.id}",
+      "arn:aws:s3:::${aws_s3_bucket.bucket.id}/*",
     ]
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -83,15 +83,8 @@ data "aws_iam_policy_document" "policy" {
   }
 }
 
-resource "aws_iam_policy" "policy" {
-  name        = "${aws_s3_bucket.s3bucket.bucket}-s3-policy"
-  path        = "/teams/${var.team_name}/"
-  policy      = "${data.aws_iam_policy_document.policy.json}"
-  description = "Policy for S3 bucket ${aws_s3_bucket.s3bucket.bucket}"
-}
-
-resource "aws_iam_policy_attachment" "attach-policy" {
-  name       = "attached-policy"
-  users      = ["${aws_iam_user.s3-account.name}"]
-  policy_arn = "${aws_iam_policy.policy.arn}"
+resource "aws_iam_user_policy" "policy" {
+  name   = "s3-bucket-read-write"
+  policy = "${data.aws_iam_policy_document.policy.json}"
+  user   = "${aws_iam_user.s3-account.name}"
 }

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,7 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-resource "aws_s3_bucket" "s3bucket" {
+resource "aws_s3_bucket" "bucket" {
   bucket        = "${var.business-unit}-${var.team_name}-${var.bucket_identifier}"
   acl           = "${var.acl}"
   force_destroy = "true"
@@ -33,13 +33,13 @@ resource "random_id" "user" {
   byte_length = 8
 }
 
-resource "aws_iam_user" "s3-account" {
+resource "aws_iam_user" "user" {
   name = "s3-bucket-user-${random_id.user.hex}"
   path = "/system/s3-bucket-user/${var.team_name}/"
 }
 
-resource "aws_iam_access_key" "s3-account-access-key" {
-  user = "${aws_iam_user.s3-account.name}"
+resource "aws_iam_access_key" "user" {
+  user = "${aws_iam_user.user.name}"
 }
 
 data "aws_iam_policy_document" "policy" {
@@ -81,8 +81,8 @@ data "aws_iam_policy_document" "policy" {
     ]
 
     resources = [
-      "arn:aws:s3:::${aws_s3_bucket.s3bucket.bucket}",
-      "arn:aws:s3:::${aws_s3_bucket.s3bucket.bucket}/*",
+      "arn:aws:s3:::${aws_s3_bucket.bucket.bucket}",
+      "arn:aws:s3:::${aws_s3_bucket.bucket.bucket}/*",
     ]
   }
 }
@@ -90,5 +90,5 @@ data "aws_iam_policy_document" "policy" {
 resource "aws_iam_user_policy" "policy" {
   name   = "s3-bucket-read-write"
   policy = "${data.aws_iam_policy_document.policy.json}"
-  user   = "${aws_iam_user.s3-account.name}"
+  user   = "${aws_iam_user.user.name}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,3 @@
-output "policy_arn" {
-  description = "ARN for the new policy"
-  value       = "${aws_iam_policy.policy.arn}"
-}
-
 output "iam_user_name" {
   description = "user name for s3 service account"
   value       = "${aws_iam_user.s3-account.name}"

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,3 @@
-output "iam_user_name" {
-  description = "user name for s3 service account"
-  value       = "${aws_iam_user.s3-account.name}"
-}
-
 output "access_key_id" {
   description = "Access key id for s3 account"
   value       = "${aws_iam_access_key.s3-account-access-key.id}"
@@ -20,10 +15,5 @@ output "bucket_arn" {
 
 output "bucket_name" {
   description = "bucket name"
-  value       = "${aws_s3_bucket.s3bucket.bucket}"
-}
-
-output "user_arn" {
-  description = "Arn for iam user"
-  value       = "${aws_iam_user.s3-account.arn}"
+  value       = "${aws_s3_bucket.bucket.bucket}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,16 +1,16 @@
 output "access_key_id" {
   description = "Access key id for s3 account"
-  value       = "${aws_iam_access_key.s3-account-access-key.id}"
+  value       = "${aws_iam_access_key.user.id}"
 }
 
 output "secret_access_key" {
   description = "Secret key for s3 account"
-  value       = "${aws_iam_access_key.s3-account-access-key.secret}"
+  value       = "${aws_iam_access_key.user.secret}"
 }
 
 output "bucket_arn" {
   description = "Arn for s3 bucket created"
-  value       = "${aws_s3_bucket.s3bucket.arn}"
+  value       = "${aws_s3_bucket.bucket.arn}"
 }
 
 output "bucket_name" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,5 +15,5 @@ output "bucket_arn" {
 
 output "bucket_name" {
   description = "bucket name"
-  value       = "${aws_s3_bucket.bucket.bucket}"
+  value       = "${aws_s3_bucket.bucket.id}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,9 +1,5 @@
 variable "team_name" {}
 
-variable "bucket_identifier" {
-  description = "This is the bucket identifier, the bucket name will be this prefixed with your team name"
-}
-
 variable "acl" {
   description = "acl manages access to your bucket"
   default     = "private"


### PR DESCRIPTION
As per the commit messages and similar changes in https://github.com/ministryofjustice/cloud-platform-terraform-ecr-credentials/pull/3:

- Removed policy resource; it's not reusable so it's fine to attach directly on the user
- Changed IAM usernames and S3 bucket names to use a prefix and a randomised suffix due to a 64 (63 for S3) character limit
- Removed unneeded outputs
