### PR TITLE
Revisited IAM policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -45,43 +45,42 @@ resource "aws_iam_access_key" "user" {
 data "aws_iam_policy_document" "policy" {
   statement {
     actions = [
-      "s3:GetBucketTagging",
-      "s3:DeleteObjectVersion",
-      "s3:GetObjectVersionTagging",
-      "s3:ListBucketVersions",
-      "s3:GetBucketLogging",
-      "s3:RestoreObject",
-      "s3:ReplicateObject",
-      "s3:GetObjectVersionTorrent",
-      "s3:GetObjectAcl",
-      "s3:GetEncryptionConfiguration",
-      "s3:AbortMultipartUpload",
-      "s3:GetBucketRequestPayment",
-      "s3:GetObjectVersionAcl",
-      "s3:GetObjectTagging",
-      "s3:PutObjectTagging",
-      "s3:DeleteObject",
-      "s3:GetIpConfiguration",
-      "s3:DeleteObjectTagging",
-      "s3:ListBucketMultipartUploads",
-      "s3:GetBucketWebsite",
-      "s3:PutObjectVersionTagging",
-      "s3:DeleteObjectVersionTagging",
-      "s3:GetBucketVersioning",
-      "s3:GetBucketNotification",
-      "s3:ListMultipartUploadParts",
-      "s3:PutObject",
-      "s3:GetObject",
-      "s3:GetObjectTorrent",
-      "s3:GetBucketCORS",
-      "s3:GetObjectVersionForReplication",
       "s3:GetBucketLocation",
-      "s3:ReplicateDelete",
-      "s3:GetObjectVersion",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:ListBucketVersions",
     ]
 
     resources = [
       "arn:aws:s3:::${aws_s3_bucket.bucket.id}",
+    ]
+  }
+
+  statement {
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:DeleteObjectTagging",
+      "s3:DeleteObjectVersion",
+      "s3:DeleteObjectVersionTagging",
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:GetObjectTagging",
+      "s3:GetObjectTorrent",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionAcl",
+      "s3:GetObjectVersionTagging",
+      "s3:GetObjectVersionTorrent",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:PutObjectTagging",
+      "s3:PutObjectVersionAcl",
+      "s3:PutObjectVersionTagging",
+      "s3:RestoreObject",
+    ]
+
+    resources = [
       "arn:aws:s3:::${aws_s3_bucket.bucket.id}/*",
     ]
   }


### PR DESCRIPTION
- Split into two statements for bucket and objects.
- Adjusted scope based on [this](https://docs.aws.amazon.com/AmazonS3/latest/dev/using-with-s3-actions.html) and [this](https://docs.aws.amazon.com/AmazonS3/latest/dev/example-policies-s3.html)

Why: `s3:PutObjectAcl` was missing so it was a good opportunity to revisit.