### PR TITLE
Introduce user_policy variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ module "example_team_s3" {
 |------|-------------|:----:|:-----:|:-----:|
 | acl | acl manages access to your bucket | string | `private` | no |
 | bucket_policy | The S3 bucket policy to set. If empty, no policy will be set | string | `""` | no |
+| bucket_policy | The IAM policy to assign to the generated user. If empty, the default policy is used | string | `""` | no |
 | versioning | version objects stored within your bucket. | boolean | `false` | no |
 
 ### Tags

--- a/example/s3.tf
+++ b/example/s3.tf
@@ -16,31 +16,67 @@ module "example_team_s3_bucket" {
   aws-s3-region          = "eu-west-2"
 
   /*
-   * This is an example of a bucket policy. It is treated as a template so that
-   * variable can be used to avoid hardcoding values. Currently, the only
-   * available variable is `$${bucket_arn}`.
+   * The following are exampls of bucket and user policies. They are treated as
+   * templates. Currently, the only available variable is `$${bucket_arn}`.
    *
+   */
 
-  bucket_policy = <<EOF
+  /*
+ * Allow a user (foobar) from another account (012345678901) to get objects from
+ * this bucket.
+ *
+
+   bucket_policy = <<EOF
 {
-  "Version":"2012-10-17",
+  "Version": "2012-10-17",
   "Statement": [
-        {
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam::012345678901:user/foobar"
-            },
-            "Action": [
-                "s3:GetObject"
-            ],
-            "Resource": [
-                "$${bucket_arn}/*"
-            ]
-        }
-    ]
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::012345678901:user/foobar"
+      },
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "$${bucket_arn}/*"
+      ]
+    }
+  ]
 }
 EOF
-  */
+
+*/
+
+  /*
+ * Override the default policy for the generated machine user of this bucket.
+ *
+
+user_policy = <<EOF
+{
+"Version": "2012-10-17",
+"Statement": [
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetBucketLocation"
+    ],
+    "Resource": "$${bucket_arn}"
+  },
+  {
+    "Sid": "",
+    "Effect": "Allow",
+    "Action": [
+      "s3:GetObject"
+    ],
+    "Resource": "$${bucket_arn}/*"
+  }
+]
+}
+EOF
+
+*/
 }
 
 resource "kubernetes_secret" "example_team_s3_bucket" {

--- a/main.tf
+++ b/main.tf
@@ -18,6 +18,14 @@ data "template_file" "bucket_policy" {
   }
 }
 
+data "template_file" "user_policy" {
+  template = "${var.user_policy}"
+
+  vars {
+    bucket_arn = "arn:aws:s3:::cloud-platform-${random_id.id.hex}"
+  }
+}
+
 resource "aws_s3_bucket" "bucket" {
   provider      = "aws.destination"
   bucket        = "cloud-platform-${random_id.id.hex}"
@@ -104,6 +112,6 @@ data "aws_iam_policy_document" "policy" {
 
 resource "aws_iam_user_policy" "policy" {
   name   = "s3-bucket-read-write"
-  policy = "${data.aws_iam_policy_document.policy.json}"
+  policy = "${data.template_file.user_policy.rendered == "" ? data.aws_iam_policy_document.policy.json : data.template_file.user_policy.rendered}"
   user   = "${aws_iam_user.user.name}"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -27,6 +27,11 @@ variable "bucket_policy" {
   default     = ""
 }
 
+variable "user_policy" {
+  description = "The IAM policy to assign to the generated user. If empty, the default policy is used"
+  default     = ""
+}
+
 variable "versioning" {
   description = "Enable object versioning for the bucket"
   default     = false


### PR DESCRIPTION
This allows us to provide a custom IAM policy for the generated IAM machine user.
Similar to bucket_policy, it is treated as a template.

Connects to https://github.com/ministryofjustice/cloud-platform/issues/777