### PR TITLE
Bugfix/module-deletion

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,7 @@ module "example_team_s3" {
   is-production          = "false"
   environment-name       = "development"
   infrastructure-support = "example-team@digtal.justice.gov.uk"
-  aws-s3-region          = "eu-west-1"
-}
+  }
 ```
 
 ## Inputs

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,9 +1,19 @@
+terraform {
+  backend "s3" {}
+}
 
 provider "aws" {
   region = "eu-west-1"
 }
 
+# To be use in case the resources need to be created in London
 provider "aws" {
-  alias = "module"
+  alias = "london"
   region = "eu-west-2"
+}
+
+# To be use in case the resources need to be created in Ireland
+provider "aws" {
+  alias = "ireland"
+  region = "eu-west-1"
 }

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,7 +1,9 @@
-terraform {
-  backend "s3" {}
-}
 
 provider "aws" {
   region = "eu-west-1"
+}
+
+provider "aws" {
+  alias = "module"
+  region = "eu-west-2"
 }

--- a/example/s3.tf
+++ b/example/s3.tf
@@ -4,20 +4,20 @@
  * releases page of this repository.
  *
  */
-# module "example_team_s3_bucket" {
-#   source = ".."
+module "example_team_s3_bucket" {
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=2.1"
 
-#   team_name              = "cloudplatform"
-#   business-unit          = "mojdigital"
-#   application            = "cloud-platform-terraform-s3-bucket"
-#   is-production          = "false"
-#   environment-name       = "development"
-#   infrastructure-support = "platform@digtal.justice.gov.uk"
-#   aws-s3-region          = "eu-west-2"
+  team_name              = "cloudplatform"
+  business-unit          = "mojdigital"
+  application            = "cloud-platform-terraform-s3-bucket"
+  is-production          = "false"
+  environment-name       = "development"
+  infrastructure-support = "platform@digtal.justice.gov.uk"
 
-#   providers = {
-#     aws = "aws.module"
-#   }
+  providers = {
+    # Can be either "aws.london" or "aws.ireland"
+    aws = "aws.ireland"
+  }
 
   /*
    * The following are exampls of bucket and user policies. They are treated as
@@ -81,4 +81,18 @@ user_policy = <<EOF
 EOF
 
 */
-# }
+}
+
+resource "kubernetes_secret" "example_team_s3_bucket" {
+  metadata {
+    name      = "example-team-s3-bucket-output"
+    namespace = "my-namespace"
+  }
+
+  data {
+    access_key_id     = "${module.example_team_s3_bucket.access_key_id}"
+    secret_access_key = "${module.example_team_s3_bucket.secret_access_key}"
+    bucket_arn        = "${module.example_team_s3_bucket.bucket_arn}"
+    bucket_name       = "${module.example_team_s3_bucket.bucket_name}"
+  }
+}

--- a/example/s3.tf
+++ b/example/s3.tf
@@ -4,16 +4,20 @@
  * releases page of this repository.
  *
  */
-module "example_team_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=2.0"
+# module "example_team_s3_bucket" {
+#   source = ".."
 
-  team_name              = "cloudplatform"
-  business-unit          = "mojdigital"
-  application            = "cloud-platform-terraform-s3-bucket"
-  is-production          = "false"
-  environment-name       = "development"
-  infrastructure-support = "platform@digtal.justice.gov.uk"
-  aws-s3-region          = "eu-west-2"
+#   team_name              = "cloudplatform"
+#   business-unit          = "mojdigital"
+#   application            = "cloud-platform-terraform-s3-bucket"
+#   is-production          = "false"
+#   environment-name       = "development"
+#   infrastructure-support = "platform@digtal.justice.gov.uk"
+#   aws-s3-region          = "eu-west-2"
+
+#   providers = {
+#     aws = "aws.module"
+#   }
 
   /*
    * The following are exampls of bucket and user policies. They are treated as
@@ -77,18 +81,4 @@ user_policy = <<EOF
 EOF
 
 */
-}
-
-resource "kubernetes_secret" "example_team_s3_bucket" {
-  metadata {
-    name      = "example-team-s3-bucket-output"
-    namespace = "my-namespace"
-  }
-
-  data {
-    access_key_id     = "${module.example_team_s3_bucket.access_key_id}"
-    secret_access_key = "${module.example_team_s3_bucket.secret_access_key}"
-    bucket_arn        = "${module.example_team_s3_bucket.bucket_arn}"
-    bucket_name       = "${module.example_team_s3_bucket.bucket_name}"
-  }
-}
+# }

--- a/example/s3.tf
+++ b/example/s3.tf
@@ -5,7 +5,7 @@
  *
  */
 module "example_team_s3_bucket" {
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=2.1"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=3.2"
 
   team_name              = "cloudplatform"
   business-unit          = "mojdigital"

--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,6 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-provider "aws" {
-  alias  = "destination"
-  region = "${var.aws-s3-region}"
-}
-
 resource "random_id" "id" {
   byte_length = 16
 }
@@ -27,7 +22,7 @@ data "template_file" "user_policy" {
 }
 
 resource "aws_s3_bucket" "bucket" {
-  provider      = "aws.destination"
+  provider      = "aws.module"
   bucket        = "cloud-platform-${random_id.id.hex}"
   acl           = "${var.acl}"
   force_destroy = "true"

--- a/main.tf
+++ b/main.tf
@@ -22,11 +22,9 @@ data "template_file" "user_policy" {
 }
 
 resource "aws_s3_bucket" "bucket" {
-  provider      = "aws.module"
   bucket        = "cloud-platform-${random_id.id.hex}"
   acl           = "${var.acl}"
   force_destroy = "true"
-  region        = "${var.aws-s3-region}"
   policy        = "${data.template_file.bucket_policy.rendered}"
 
   server_side_encryption_configuration {
@@ -48,7 +46,6 @@ resource "aws_s3_bucket" "bucket" {
     environment-name       = "${var.environment-name}"
     owner                  = "${var.team_name}"
     infrastructure-support = "${var.infrastructure-support}"
-    aws-s3-region          = "${var.aws-s3-region}"
   }
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -37,7 +37,3 @@ variable "versioning" {
   default     = false
 }
 
-variable "aws-s3-region" {
-  description = "Region into which the bucket will be created"
-  default     = "eu-west-2"
-}


### PR DESCRIPTION
 #861 

By taking the provider definition out of the module, the module's resources can now be deleted without breaking the pipeline.

what changed : 
-  removed all mentioned of aws_region variable from the module's core.
- added the providers aws.london and aws.ireland to example/main.tf
- updated the invocation of the module in example/s3.tf
