### PR TITLE
add cors_rule support to s3 module

### DIFF
--- a/example/s3.tf
+++ b/example/s3.tf
@@ -20,11 +20,33 @@ module "example_team_s3_bucket" {
   }
 
   /*
+   * The following example can be used if you need to define CORS rules for your s3 bucket. 
+   *  Follow the guidance here "https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-cors"
+   *  
+
+  cors_rule =[
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["GET"]
+      allowed_origins = ["https://s3-website-test.hashicorp.com"]
+      expose_headers  = ["ETag"]
+      max_age_seconds = 3000
+    },
+    {
+      allowed_headers = ["*"]
+      allowed_methods = ["PUT"]
+      allowed_origins = ["https://s3-website-test.hashicorp.com"]
+      expose_headers  = [""]
+      max_age_seconds = 3000
+    },
+  ]
+
+
+  /*
    * The following example can be used if you need to set a lifecycle for your s3. 
    *  Follow the guidance here "https://www.terraform.io/docs/providers/aws/r/s3_bucket.html#using-object-lifecycle"
    *  "https://docs.aws.amazon.com/AmazonS3/latest/dev/object-lifecycle-mgmt.html"
-   *  
-
+   *
   lifecycle_rule = [
     {
       enabled = true

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,8 @@ resource "aws_s3_bucket" "bucket" {
   policy        = "${data.template_file.bucket_policy.rendered}"
 
   lifecycle_rule = "${var.lifecycle_rule}"
+  
+  cors_rule      = "${var.cors_rule}"
 
   server_side_encryption_configuration {
     rule {

--- a/variables.tf
+++ b/variables.tf
@@ -41,3 +41,8 @@ variable "lifecycle_rule" {
   description = "lifecycle"
   default     = []
 }
+
+variable "cors_rule" {
+  description = "cors rule"
+  default = []
+}


### PR DESCRIPTION
This allows service-team to define and maintain cors rule for their S3 Buckets. 

A new `cors_rule` input can optionally be used when invocating the module.