### PR TITLE
draft terraform 0.12.13 upgrade

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -1,19 +1,20 @@
 output "access_key_id" {
   description = "Access key id for s3 account"
-  value       = "${aws_iam_access_key.user.id}"
+  value       = aws_iam_access_key.user.id
 }
 
 output "secret_access_key" {
   description = "Secret key for s3 account"
-  value       = "${aws_iam_access_key.user.secret}"
+  value       = aws_iam_access_key.user.secret
 }
 
 output "bucket_arn" {
   description = "Arn for s3 bucket created"
-  value       = "${aws_s3_bucket.bucket.arn}"
+  value       = aws_s3_bucket.bucket.arn
 }
 
 output "bucket_name" {
   description = "bucket name"
-  value       = "${aws_s3_bucket.bucket.id}"
+  value       = aws_s3_bucket.bucket.id
 }
+

--- a/variables.tf
+++ b/variables.tf
@@ -1,8 +1,11 @@
-variable "team_name" {}
+variable "team_name" {
+}
 
-variable "application" {}
+variable "application" {
+}
 
-variable "environment-name" {}
+variable "environment-name" {
+}
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service"
@@ -44,5 +47,6 @@ variable "lifecycle_rule" {
 
 variable "cors_rule" {
   description = "cors rule"
-  default = []
+  default     = []
 }
+

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,4 @@
+
+terraform {
+  required_version = ">= 0.12"
+}


### PR DESCRIPTION
To upgrade the module do:
when in terraform0.11.14 version, do terraform 0.12checklist
switch to terraform 0.12.13 using tfswitch
do terraform 0.12upgrade

`lifecycle_rule` and `cors_rule` have changed to tf12 spec to include dynamic nested blocks.

Tested with newly defined `lifecycle_rule` and `cors_rule` and working fine.

example/*.tf updates are available in `tf12-example-upgrade` branch and will be merged when needed.