### PR TITLE
Block public access resource added

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,9 @@ module "example_team_s3" {
                     acl                           = "public-read"
                     enable_allow_block_pub_access = false
 
+                    For more information granting public access to S3 buckets, please see AWS documentation: 
+                    https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
+
   * Converting existing private bucket to public: If amending an existing private bucket that was created using version 4.3 or above then you will need to raise two PRs:
                     
                     (1) First PR to add the var: enable_allow_block_pub_access = false

--- a/README.md
+++ b/README.md
@@ -26,6 +26,18 @@ module "example_team_s3" {
   infrastructure-support = "example-team@digtal.justice.gov.uk"
 
  /* 
+
+  * Public Buckets: It is strongly advised to keep buckets 'private' and only make public where necessary. 
+                    By default buckets are private, however to create a 'public' bucket add the following two variables when calling the module:
+
+                    acl                           = "public-read"
+                    enable_allow_block_pub_access = false
+
+  * Converting existing private bucket to public: If amending an existing private bucket that was created using version 4.3 or above then you will need to raise two PRs:
+                    
+                    (1) First PR to add the var: enable_allow_block_pub_access = false
+                    (2) Second PR to add the var: acl = "public-read"
+
   * Versioning: By default this is set to false. When set to true multiple versions of an object can be stored
                 For more details on versioning please visit: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
   
@@ -199,3 +211,6 @@ aws s3 sync --delete \
 ```
 
 For an example of a pod with a custom CLI that wraps s3 sync you can see the [cccd-migrator](https://github.com/ministryofjustice/cccd-migrator)
+
+
+

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,4 +1,9 @@
 
+terraform {
+  backend "s3" {
+  }
+}
+
 provider "aws" {
   region = "eu-west-1"
 }

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,7 +1,3 @@
-terraform {
-  backend "s3" {
-  }
-}
 
 provider "aws" {
   region = "eu-west-1"

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,6 +1,6 @@
 
 terraform {
-  backend "s3" {
+   backend "s3" {
   }
 }
 

--- a/example/s3.tf
+++ b/example/s3.tf
@@ -6,7 +6,7 @@
  */
 module "example_team_s3_bucket" {
 
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.2"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
   team_name              = "cloudplatform"
   business-unit          = "mojdigital"
   application            = "cloud-platform-terraform-s3-bucket"
@@ -16,10 +16,16 @@ module "example_team_s3_bucket" {
 
  /* 
 
-  Public Buckets: By default, buckets are private, however to create a 'public' bucket add the following two variables when calling the module
+  * Public Buckets: It is strongly advised to keep buckets 'private' and only make public where necessary. 
+                    By default buckets are private, however to create a 'public' bucket add the following two variables when calling the module:
+
                     acl                           = "public-read"
                     enable_allow_block_pub_access = false
-                  
+
+  * Converting existing private bucket to public: If amending an existing private bucket that was created using version 4.3 or above then you will need to raise two PRs:
+                    
+                    (1) First PR to add the var: enable_allow_block_pub_access = false
+                    (2) Second PR to add the var: acl = "public-read"
 
   * Versioning: By default this is set to false. When set to true multiple versions of an object can be stored
                 For more details on versioning please visit: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html

--- a/example/s3.tf
+++ b/example/s3.tf
@@ -6,8 +6,7 @@
  */
 module "example_team_s3_bucket" {
 
-  //source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.2"
-  source = "../"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.2"
   team_name              = "cloudplatform"
   business-unit          = "mojdigital"
   application            = "cloud-platform-terraform-s3-bucket"
@@ -15,8 +14,13 @@ module "example_team_s3_bucket" {
   environment-name       = "development"
   infrastructure-support = "platform@digtal.justice.gov.uk"
 
-
  /* 
+
+  Public Buckets: By default, buckets are private, however to create a 'public' bucket add the following two variables when calling the module
+                    acl                           = "public-read"
+                    enable_allow_block_pub_access = false
+                  
+
   * Versioning: By default this is set to false. When set to true multiple versions of an object can be stored
                 For more details on versioning please visit: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
   

--- a/example/s3.tf
+++ b/example/s3.tf
@@ -180,3 +180,16 @@ EOF
 }
 
 
+resource "kubernetes_secret" "example_team_s3_bucket" {
+  metadata {
+    name      = "example-team-s3-bucket-output"
+    namespace = "my-namespace"
+  }
+
+  data = {
+    access_key_id     = module.example_team_s3_bucket.access_key_id
+    secret_access_key = module.example_team_s3_bucket.secret_access_key
+    bucket_arn        = module.example_team_s3_bucket.bucket_arn
+    bucket_name       = module.example_team_s3_bucket.bucket_name
+  }
+}

--- a/example/s3.tf
+++ b/example/s3.tf
@@ -22,6 +22,9 @@ module "example_team_s3_bucket" {
                     acl                           = "public-read"
                     enable_allow_block_pub_access = false
 
+                    For more information granting public access to S3 buckets, please see AWS documentation: 
+                    https://docs.aws.amazon.com/AmazonS3/latest/dev/access-control-block-public-access.html
+
   * Converting existing private bucket to public: If amending an existing private bucket that was created using version 4.3 or above then you will need to raise two PRs:
                     
                     (1) First PR to add the var: enable_allow_block_pub_access = false

--- a/example/s3.tf
+++ b/example/s3.tf
@@ -6,13 +6,16 @@
  */
 module "example_team_s3_bucket" {
 
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.2"
+  //source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.2"
+  source = "../"
   team_name              = "cloudplatform"
   business-unit          = "mojdigital"
   application            = "cloud-platform-terraform-s3-bucket"
   is-production          = "false"
   environment-name       = "development"
   infrastructure-support = "platform@digtal.justice.gov.uk"
+
+
  /* 
   * Versioning: By default this is set to false. When set to true multiple versions of an object can be stored
                 For more details on versioning please visit: https://docs.aws.amazon.com/AmazonS3/latest/dev/Versioning.html
@@ -163,17 +166,4 @@ EOF
   }
 }
 
-resource "kubernetes_secret" "example_team_s3_bucket" {
-  metadata {
-    name      = "example-team-s3-bucket-output"
-    namespace = "my-namespace"
-  }
-
-  data = {
-    access_key_id     = module.example_team_s3_bucket.access_key_id
-    secret_access_key = module.example_team_s3_bucket.secret_access_key
-    bucket_arn        = module.example_team_s3_bucket.bucket_arn
-    bucket_name       = module.example_team_s3_bucket.bucket_name
-  }
-}
 

--- a/main.tf
+++ b/main.tf
@@ -25,6 +25,7 @@ data "template_file" "user_policy" {
 }
 
 resource "aws_s3_bucket" "bucket" {
+
   bucket        = "cloud-platform-${random_id.id.hex}"
   acl           = var.acl
   force_destroy = "true"
@@ -183,5 +184,17 @@ resource "aws_iam_user_policy" "policy" {
   name   = "s3-bucket-read-write"
   policy = data.template_file.user_policy.rendered == "" ? data.aws_iam_policy_document.policy.json : data.template_file.user_policy.rendered
   user   = aws_iam_user.user.name
+}
+
+resource "aws_s3_bucket_public_access_block" "block_public_access" {
+
+  count = var.enable_allow_block_pub_access ? 1 : 0
+  bucket = aws_s3_bucket.bucket.id
+
+  block_public_acls   = true
+  block_public_policy = true
+  ignore_public_acls      = true 
+  restrict_public_buckets = true 
+
 }
 

--- a/main.tf
+++ b/main.tf
@@ -188,13 +188,13 @@ resource "aws_iam_user_policy" "policy" {
 
 resource "aws_s3_bucket_public_access_block" "block_public_access" {
 
-  count = var.enable_allow_block_pub_access ? 1 : 0
+  count  = var.enable_allow_block_pub_access ? 1 : 0
   bucket = aws_s3_bucket.bucket.id
 
-  block_public_acls   = true
-  block_public_policy = true
-  ignore_public_acls      = true 
-  restrict_public_buckets = true 
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
 
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -66,3 +66,9 @@ variable "cors_rule" {
   default     = []
 }
 
+
+variable "enable_allow_block_pub_access" {
+  description = "Enable whether to allow for the bucket to be blocked from public access"
+  default     = true
+  type        = bool
+}

--- a/variables.tf
+++ b/variables.tf
@@ -42,17 +42,17 @@ variable "versioning" {
 
 variable "log_target_bucket" {
   description = "Set the target bucket for logs"
-  default = ""
+  default     = ""
 }
 
 variable "logging_enabled" {
   description = "Set the logging for bucket"
-  default = false
+  default     = false
 }
 
 variable "log_path" {
   description = "Set the path of the logs"
-  default = ""
+  default     = ""
 }
 
 


### PR DESCRIPTION
New resource block added 'aws_s3_bucket_public_access_block' with related vars of 'acl' and 'enable_allow_block_pub_access'. With exception to 'acl' being 'public-read' all other buckets will have 'block public access' set to ON by default. 

                