### PR TITLE
Adding support for bucket name

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ module "example_team_s3" {
 | log_target_bucket | Target bucket where logs are to be delivered to
   log_path           | Path of logs on the target bucket e.g log/
 | providers | provider to use | array of string | default provider | no
+| bucket_name | bucket_name, not recommended | string| empty, auto-generated | no
+
+
 
 ### Tags
 

--- a/example/s3.tf
+++ b/example/s3.tf
@@ -6,7 +6,7 @@
  */
 module "example_team_s3_bucket" {
 
-  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
+  source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.4"
   team_name              = "cloudplatform"
   business-unit          = "mojdigital"
   application            = "cloud-platform-terraform-s3-bucket"

--- a/main.tf
+++ b/main.tf
@@ -12,7 +12,7 @@ data "template_file" "bucket_policy" {
   template = var.bucket_policy
 
   vars = {
-    bucket_arn = "arn:aws:s3:::cloud-platform-${random_id.id.hex}"
+    bucket_arn = "arn:aws:s3:::${local.bucket_name}"
   }
 }
 
@@ -20,13 +20,16 @@ data "template_file" "user_policy" {
   template = var.user_policy
 
   vars = {
-    bucket_arn = "arn:aws:s3:::cloud-platform-${random_id.id.hex}"
+    bucket_arn = "arn:aws:s3:::${local.bucket_name}"
   }
 }
 
-resource "aws_s3_bucket" "bucket" {
+locals {
+  bucket_name = var.bucket_name == "" ? "cloud-platform-${random_id.id.hex}" : var.bucket_name
+}
 
-  bucket        = "cloud-platform-${random_id.id.hex}"
+resource "aws_s3_bucket" "bucket" {
+  bucket        = local.bucket_name
   acl           = var.acl
   force_destroy = "true"
   policy        = data.template_file.bucket_policy.rendered

--- a/variables.tf
+++ b/variables.tf
@@ -50,6 +50,11 @@ variable "logging_enabled" {
   default     = false
 }
 
+variable "bucket_name"{
+  description = "Set the name of the S3 bucket. If left blank, a name will be automatically generated (recommended)"
+  default = ""
+}
+
 variable "log_path" {
   description = "Set the path of the logs"
   default     = ""


### PR DESCRIPTION
This PR introduces an extra variable `bucket_name`. 
It allows teams to choose their bucket name, instead of relying on the auto-generated one. 

Using the automatically generated name is still the recommended method. 

https://github.com/ministryofjustice/cloud-platform/issues/2128