### PR TITLE
Correct the variable names

### DIFF
--- a/template/s3.tmpl
+++ b/template/s3.tmpl
@@ -2,12 +2,12 @@ module "s3_bucket" {
   source = "github.com/ministryofjustice/cloud-platform-terraform-s3-bucket?ref=4.3"
   acl    = "private"
 
-  team_name              = var.team-name
-  business-unit          = var.business-unit
+  team_name              = var.team_name
+  business-unit          = var.business_unit
   application            = var.application
-  is-production          = var.is-production
-  environment-name       = var.environment-name
-  infrastructure-support = var.infrastructure-support
+  is-production          = var.is_production
+  environment-name       = var.environment
+  infrastructure-support = var.infrastructure_support
 
   providers = {
     aws = aws.london


### PR DESCRIPTION
* environment, not environment-name
* switch to snake-case variable names

We have a policy to use snake-case variable names for all terraform
code. The default variables.tf file now has snake-case variables, so we
can use those.
