### PR TITLE
Using localstack rather than real AWS Account

### DIFF
--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -6,9 +6,18 @@ jobs:
   go-tests:
     name: Run Terratest Unit Tests
     runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+    services:
+      localstack:
+        image: localstack/localstack:latest
+        env:
+          SERVICES: iam,sts,s3
+          DEFAULT_REGION: eu-west-2
+          AWS_ACCESS_KEY_ID: localkey
+          AWS_SECRET_ACCESS_KEY: localsecret
+          HOSTNAME_EXTERNAL: localstack
+        ports:
+          - 4566:4566
+          - 4571:4571
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/unit.yml
+++ b/.github/workflows/unit.yml
@@ -12,9 +12,6 @@ jobs:
         env:
           SERVICES: iam,sts,s3
           DEFAULT_REGION: eu-west-2
-          AWS_ACCESS_KEY_ID: localkey
-          AWS_SECRET_ACCESS_KEY: localsecret
-          HOSTNAME_EXTERNAL: localstack
         ports:
           - 4566:4566
           - 4571:4571

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -3,7 +3,20 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-2"
+  access_key                  = "mock_access_key"
+  secret_key                  = "mock_secret_key"
+  region                      = "eu-west-2"
+  s3_force_path_style         = true
+  skip_credentials_validation = true
+  skip_metadata_api_check     = true
+  skip_requesting_account_id  = true
+
+  endpoints {
+    ec2            = "http://localhost:4566"
+    iam            = "http://localhost:4566"
+    s3             = "http://localhost:4566"
+    sts            = "http://localhost:4566"
+  }
 }
 
 module "s3" {


### PR DESCRIPTION
For the integration tests, it might be useful a real AWS account. For unit-tests, the TF module localstack is more than enough,