### PR TITLE
Add missing variable types and descriptions; give providers minimum versions

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -193,7 +193,6 @@ resource "aws_iam_user_policy" "policy" {
 }
 
 resource "aws_s3_bucket_public_access_block" "block_public_access" {
-
   count  = var.enable_allow_block_pub_access ? 1 : 0
   bucket = aws_s3_bucket.bucket.id
 
@@ -201,6 +200,4 @@ resource "aws_s3_bucket_public_access_block" "block_public_access" {
   block_public_policy     = true
   ignore_public_acls      = true
   restrict_public_buckets = true
-
 }
-

--- a/test/unit-test/main.tf
+++ b/test/unit-test/main.tf
@@ -12,10 +12,10 @@ provider "aws" {
   skip_requesting_account_id  = true
 
   endpoints {
-    ec2            = "http://localhost:4566"
-    iam            = "http://localhost:4566"
-    s3             = "http://localhost:4566"
-    sts            = "http://localhost:4566"
+    ec2 = "http://localhost:4566"
+    iam = "http://localhost:4566"
+    s3  = "http://localhost:4566"
+    sts = "http://localhost:4566"
   }
 }
 
@@ -30,4 +30,3 @@ module "s3" {
   infrastructure-support = "platform@digtal.justice.gov.uk"
   namespace              = "cloud-platform"
 }
-

--- a/test/unit-test/outputs.tf
+++ b/test/unit-test/outputs.tf
@@ -7,4 +7,3 @@ output "bucket_name" {
   description = "bucket name"
   value       = module.s3.bucket_name
 }
-

--- a/variables.tf
+++ b/variables.tf
@@ -1,79 +1,99 @@
 variable "team_name" {
+  description = "Your team name"
+  type        = string
 }
 
 variable "application" {
+  description = "Your application name"
+  type        = string
 }
 
 variable "environment-name" {
+  description = "Your environment name"
+  type        = string
 }
 
 variable "namespace" {
+  description = "Your namespace"
+  type        = string
 }
 
 variable "business-unit" {
   description = "Area of the MOJ responsible for the service"
   default     = "mojdigital"
+  type        = string
 }
 
 variable "is-production" {
-  default = "false"
+  default     = "false"
+  description = "Whether this S3 bucket is for production or not"
+  type        = string
 }
 
 variable "infrastructure-support" {
   description = "The team responsible for managing the infrastructure. Should be of the form <team-name> (<team-email>)"
+  type        = string
 }
 
 variable "acl" {
   description = "The bucket ACL to set"
   default     = "private"
+  type        = string
 }
 
 variable "bucket_policy" {
   description = "The S3 bucket policy to set. If empty, no policy will be set"
   default     = ""
+  type        = string
 }
 
 variable "user_policy" {
   description = "The IAM policy to assign to the generated user. If empty, the default policy is used"
   default     = ""
+  type        = string
 }
 
 variable "versioning" {
   description = "Enable object versioning for the bucket"
   default     = false
+  type        = bool
 }
 
 variable "log_target_bucket" {
   description = "Set the target bucket for logs"
   default     = ""
+  type        = string
 }
 
 variable "logging_enabled" {
   description = "Set the logging for bucket"
   default     = false
+  type        = bool
 }
 
 variable "bucket_name" {
   description = "Set the name of the S3 bucket. If left blank, a name will be automatically generated (recommended)"
   default     = ""
+  type        = string
 }
 
 variable "log_path" {
   description = "Set the path of the logs"
   default     = ""
+  type        = string
 }
-
 
 variable "lifecycle_rule" {
   description = "lifecycle"
   default     = []
+  type        = list(any)
 }
 
 variable "cors_rule" {
   description = "cors rule"
   default     = []
+  type        = list(any)
 }
-
 
 variable "enable_allow_block_pub_access" {
   description = "Enable whether to allow for the bucket to be blocked from public access"

--- a/versions.tf
+++ b/versions.tf
@@ -1,14 +1,17 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 3.0.0"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = ">= 3.0.0"
     }
     template = {
-      source = "hashicorp/template"
+      source  = "hashicorp/template"
+      version = ">= 2.0.0"
     }
   }
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
 }

--- a/versions.tf
+++ b/versions.tf
@@ -6,7 +6,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 3.0.0"
+      version = ">= 2.0.0"
     }
     template = {
       source  = "hashicorp/template"


### PR DESCRIPTION
This PR does the following:

- runs terraform fmt
- adds missing variable types and descriptions
- gives defined providers a minimum version to use