### PR TITLE
Change variable types to any() for mixed lists

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -86,13 +86,13 @@ variable "log_path" {
 variable "lifecycle_rule" {
   description = "lifecycle"
   default     = []
-  type        = list(any)
+  type        = any # list(any)
 }
 
 variable "cors_rule" {
   description = "cors rule"
   default     = []
-  type        = list(any)
+  type        = any # list(any)
 }
 
 variable "enable_allow_block_pub_access" {


### PR DESCRIPTION
This PR changes the variable type from `list(any)` to `any` as Terraform will evaluate one list item and expect all values to match the types.