### PR TITLE
Remove access keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ module "s3" {
 
 ### Migrate from existing buckets
 
+<!-- TODO: Needs rewriting after removal of access keys. -->
+
 The `user_policy` input is useful when migrating data from existing bucket(s). For commands like `s3 ls` or `s3 sync` to work across accounts, a policy granting access must be set in 2 places: the *source bucket* and the *destination user*
 
 
@@ -233,17 +235,12 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [aws_iam_access_key.user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
 | [aws_iam_policy.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_user.user](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
-| [aws_iam_user_policy.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
 | [aws_s3_bucket.bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_public_access_block.block_public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_iam_policy_document.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [aws_iam_policy_document.policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [template_file.bucket_policy](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
-| [template_file.user_policy](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 
@@ -265,19 +262,16 @@ No modules.
 | <a name="input_logging_enabled"></a> [logging\_enabled](#input\_logging\_enabled) | Set the logging for bucket | `bool` | `false` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace name | `string` | n/a | yes |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | Team name | `string` | n/a | yes |
-| <a name="input_user_policy"></a> [user\_policy](#input\_user\_policy) | The IAM policy to assign to the generated user. If empty, the default policy is used | `string` | `""` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | Enable object versioning for the bucket | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_access_key_id"></a> [access\_key\_id](#output\_access\_key\_id) | Access key id for s3 account |
 | <a name="output_bucket_arn"></a> [bucket\_arn](#output\_bucket\_arn) | S3 bucket ARN |
 | <a name="output_bucket_domain_name"></a> [bucket\_domain\_name](#output\_bucket\_domain\_name) | Regional bucket domain name |
 | <a name="output_bucket_name"></a> [bucket\_name](#output\_bucket\_name) | S3 bucket name |
 | <a name="output_irsa_policy_arn"></a> [irsa\_policy\_arn](#output\_irsa\_policy\_arn) | IAM policy ARN for access to the S3 bucket |
-| <a name="output_secret_access_key"></a> [secret\_access\_key](#output\_secret\_access\_key) | Secret key for s3 account |
 <!-- END_TF_DOCS -->
 
 ## Tags

--- a/examples/s3.tf
+++ b/examples/s3.tf
@@ -184,9 +184,7 @@ resource "kubernetes_secret" "s3_bucket" {
   }
 
   data = {
-    access_key_id     = module.s3_bucket.access_key_id
-    secret_access_key = module.s3_bucket.secret_access_key
-    bucket_arn        = module.s3_bucket.bucket_arn
-    bucket_name       = module.s3_bucket.bucket_name
+    bucket_arn  = module.s3_bucket.bucket_arn
+    bucket_name = module.s3_bucket.bucket_name
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,15 +1,3 @@
-output "access_key_id" {
-  description = "Access key id for s3 account"
-  value       = aws_iam_access_key.user.id
-  sensitive   = true
-}
-
-output "secret_access_key" {
-  description = "Secret key for s3 account"
-  value       = aws_iam_access_key.user.secret
-  sensitive   = true
-}
-
 output "bucket_arn" {
   description = "S3 bucket ARN"
   value       = aws_s3_bucket.bucket.arn

--- a/variables.tf
+++ b/variables.tf
@@ -13,12 +13,6 @@ variable "bucket_policy" {
   type        = string
 }
 
-variable "user_policy" {
-  description = "The IAM policy to assign to the generated user. If empty, the default policy is used"
-  default     = ""
-  type        = string
-}
-
 variable "versioning" {
   description = "Enable object versioning for the bucket"
   default     = false


### PR DESCRIPTION
Related to [Deprecating long-lived credentials for modules](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/other-topics/deprecating-long-lived-credentials.html) and ministryofjustice/cloud-platform#4546, ministryofjustice/cloud-platform#4372.