### PR TITLE
fix: remove deprecated 'template' provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,16 +216,14 @@ See the [examples/](examples/) folder for more information.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.2.5 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0.0 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 2.0.0 |
-| <a name="requirement_template"></a> [template](#requirement\_template) | >= 2.0.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.0.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 2.0.0 |
-| <a name="provider_template"></a> [template](#provider\_template) | >= 2.0.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.0.0 |
 
 ## Modules
 
@@ -240,7 +238,6 @@ No modules.
 | [aws_s3_bucket_public_access_block.block_public_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_public_access_block) | resource |
 | [random_id.id](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [aws_iam_policy_document.irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
-| [template_file.bucket_policy](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 

--- a/main.tf
+++ b/main.tf
@@ -28,13 +28,8 @@ resource "random_id" "id" {
 #####################
 # Generate policies #
 #####################
-# TODO: the `template` provider has been deprecated, these need to be removed in a future release.
-data "template_file" "bucket_policy" {
-  template = var.bucket_policy
-
-  vars = {
-    bucket_arn = "arn:aws:s3:::${local.bucket_name}"
-  }
+locals {
+  bucket_policy = replace(var.bucket_policy, "$${bucket_arn}", "arn:aws:s3:::${local.bucket_name}")
 }
 
 #################
@@ -46,7 +41,7 @@ resource "aws_s3_bucket" "bucket" {
   bucket        = local.bucket_name
   acl           = var.acl
   force_destroy = "true"
-  policy        = data.template_file.bucket_policy.rendered
+  policy        = local.bucket_policy
 
   dynamic "lifecycle_rule" {
     for_each = var.lifecycle_rule

--- a/versions.tf
+++ b/versions.tf
@@ -7,11 +7,7 @@ terraform {
     }
     random = {
       source  = "hashicorp/random"
-      version = ">= 2.0.0"
-    }
-    template = {
-      source  = "hashicorp/template"
-      version = ">= 2.0.0"
+      version = ">= 3.0.0"
     }
   }
 }


### PR DESCRIPTION
[`terraform-provider-template`](https://github.com/hashicorp/terraform-provider-template) was deprecated by Hashicorp in October 2020 and hasn't had a release since. This means no binaries have ever been released for Apple Silicon, so if you have a Silicon device, you can't (or struggle to) run `terraform init` on Terraform configurations that use this module.

This replaces `template_file` usage with a generic `replace()` function for bucket policies as a workaround, as Terraform does not have an equivalent `template()` or `template_string()` function.